### PR TITLE
Use official eth2-testnet-genesis again

### DIFF
--- a/scripts/build-genesis.sh
+++ b/scripts/build-genesis.sh
@@ -7,9 +7,8 @@ setup_apps(){
     cd ./apps
 
     if ! [ -d "./eth2-testnet-genesis" ]; then
-        git clone https://github.com/pk910/eth2-testnet-genesis.git
+        git clone https://github.com/protolambda/eth2-testnet-genesis.git
         cd eth2-testnet-genesis
-        git checkout trustless-genesis-validators
         go install .
         go install github.com/protolambda/eth2-val-tools@latest
         cd ..


### PR DESCRIPTION
The [upstream PR](https://github.com/protolambda/eth2-testnet-genesis/pull/9) for our customized validator set format has been merged 🎉

This PR changes the genesis build script to use the "official" version of the tool again.\
Previously it has been using the customized version from my fork repository, which is no longer necessary. 