### PR TITLE
fix lighthouse bootnode enr generation

### DIFF
--- a/.github/workflows/build-testnet-config.yml
+++ b/.github/workflows/build-testnet-config.yml
@@ -37,7 +37,7 @@ jobs:
       run: cd dist && tar cfz network-config.tar.gz *
 
     - name: Upload full config artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./dist/network-config.tar.gz
         name: network-config.tar.gz
@@ -46,24 +46,24 @@ jobs:
       run: cd dist2 && tar cfz testnet-all.tar.gz *
 
     - name: Upload full config artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./dist2/testnet-all.tar.gz
         name: testnet-all.tar.gz
     
     - name: Upload genesis.json artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./dist/metadata/genesis.json
         name: genesis.json
     
     - name: Upload config.yaml artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./dist/metadata/config.yaml
         name: config.yaml
     - name: Upload genesis.ssz artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ./dist/metadata/genesis.ssz
         name: genesis.ssz

--- a/scripts/build-bootnodes.sh
+++ b/scripts/build-bootnodes.sh
@@ -75,7 +75,8 @@ cat ./cl-bootnodes.txt | while read line ; do
     fi
   elif [ ${bootnode_data[0]} = "lighthouse" ]; then
     rm -rf $tmp_dir/*
-    ./temp/lighthouse/lighthouse bn --testnet-dir ./dist/metadata --datadir $tmp_dir --enr-address ${bootnode_data[2]} --enr-udp-port ${bootnode_data[3]} --port ${bootnode_data[3]} &
+    echo -n 0x$(openssl rand -hex 32 | tr -d "\n") > $tmp_dir/jwtsecret
+    ./temp/lighthouse/lighthouse bn --testnet-dir ./dist/metadata --datadir $tmp_dir --execution-endpoint http://127.0.0.1:8551 --execution-jwt $tmp_dir/jwtsecret --enr-address ${bootnode_data[2]} --enr-udp-port ${bootnode_data[3]} --port ${bootnode_data[3]} &
     sleep 10
     killall lighthouse
     sleep 2


### PR DESCRIPTION
lighthouse bootnode generation failed in [latest run](https://github.com/ephemery-testnet/ephemery-genesis/actions/runs/12814798929/job/35732090480) (Build bootnodes step):
```
+ ./temp/lighthouse/lighthouse bn --testnet-dir ./dist/metadata --datadir /tmp/ci-JPS0OS3VQC --enr-address 167.235.1.185 --enr-udp-port 9040 --port 9040
error: the following required arguments were not provided:
  --execution-endpoint <EXECUTION-ENDPOINT>
Usage: lighthouse beacon_node --execution-endpoint <EXECUTION-ENDPOINT> --testnet-dir <DIR> --datadir <DIR> --enr-address <ADDRESS>... --enr-udp-port <PORT> --port <PORT>
For more information, try '--help'.
```

this PR adds the missing flags, so the bootnode enr should be available again in the next iteration.
there are enough other bootnodes available, so no further action needed for the current iteration that starts in 30mins ;)