### PR TITLE
build next genesis 2h before network start

### DIFF
--- a/scripts/check_can_release.sh
+++ b/scripts/check_can_release.sh
@@ -2,7 +2,7 @@
 
 source ./values.env
 
-min_release_time=`expr $GENESIS_TIMESTAMP - 3600`
+min_release_time=`expr $GENESIS_TIMESTAMP - 7200`
 if [ $(date +%s) -gt $min_release_time ]; then
   echo "true"
 else


### PR DESCRIPTION
This PR changes the time where the next genesis is built to 2h before network start.
This was previously set to 1h only, but given that we're running on a monthly interval now, this seems a reasonable increase.
We haven't seen massively delayed genesis releases yet,  but github workflows are also known to skip scheduled workflows from time to time when workload-load on github side is high.
This gives the workflow (which runs on a 30mins interval) more time to properly build the next iteration genesis.
